### PR TITLE
Use the og:image property from the header if all else fails

### DIFF
--- a/src/comics/_gocomics.py
+++ b/src/comics/_gocomics.py
@@ -350,6 +350,13 @@ class ComicsAPI:
                         return src
                 except Exception:
                     pass
+        
+        # Try extracting the image URL from the og:image property
+        meta = comic_html.find(
+                "meta",
+                property="og:image")
+        if meta:
+            return(meta['content'])
 
         # If all else fails, raise an error
         raise InvalidDateError(


### PR DESCRIPTION
Fixes #11 by using the og:image property in the header if other attempts to find the image_url fail.